### PR TITLE
✨ feat : 사용자 정보 반환

### DIFF
--- a/src/main/java/com/hansung/leafly/domain/member/entity/Member.java
+++ b/src/main/java/com/hansung/leafly/domain/member/entity/Member.java
@@ -9,7 +9,9 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -31,6 +33,8 @@ public class Member extends BaseEntity {
     @Column(nullable = false, name = "nick_name")
     private String nickName;
 
+    private String image;
+
     @Enumerated(EnumType.STRING)
     private MemberRole role;
 
@@ -38,10 +42,10 @@ public class Member extends BaseEntity {
     private Onboarding onboarding;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Bookmark> bookmarks = new ArrayList<>();
+    private Set<Bookmark> bookmarks = new HashSet<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Library> libraries = new ArrayList<>();
+    private Set<Library> libraries = new HashSet<>();
 
     public static Member toEntity(String email, String encoded, String nickName){
         return Member.builder()

--- a/src/main/java/com/hansung/leafly/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/hansung/leafly/domain/member/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package com.hansung.leafly.domain.member.repository;
 
 import com.hansung.leafly.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -12,4 +13,12 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     Optional<Member> findByEmail(String email);
+
+    @Query("""
+        select m from Member m
+        left join fetch m.libraries
+        left join fetch m.bookmarks
+        where m.id = :memberId
+    """)
+    Optional<Member> findDetailById(Long memberId);
 }

--- a/src/main/java/com/hansung/leafly/domain/member/service/MemberService.java
+++ b/src/main/java/com/hansung/leafly/domain/member/service/MemberService.java
@@ -10,4 +10,6 @@ public interface MemberService {
     LoginRes login(LoginReq loginReq);
 
     void onboarding(Member member, OnboardingReq req);
+
+    MemberDetailsRes details(Member member);
 }

--- a/src/main/java/com/hansung/leafly/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/hansung/leafly/domain/member/service/MemberServiceImpl.java
@@ -1,5 +1,7 @@
 package com.hansung.leafly.domain.member.service;
 
+import com.hansung.leafly.domain.bookmark.entity.Bookmark;
+import com.hansung.leafly.domain.library.entity.Library;
 import com.hansung.leafly.domain.member.entity.Genre;
 import com.hansung.leafly.domain.member.entity.Member;
 import com.hansung.leafly.domain.member.entity.Onboarding;
@@ -7,20 +9,25 @@ import com.hansung.leafly.domain.member.entity.enums.GenreType;
 import com.hansung.leafly.domain.member.exception.AlreadyOnboardedException;
 import com.hansung.leafly.domain.member.exception.InvalidCredentialsException;
 import com.hansung.leafly.domain.member.exception.MemberAlreadyExistException;
+import com.hansung.leafly.domain.member.exception.MemberNotFoundException;
 import com.hansung.leafly.domain.member.repository.GenreRepository;
 import com.hansung.leafly.domain.member.repository.MemberRepository;
 import com.hansung.leafly.domain.member.repository.OnboardingRepository;
 import com.hansung.leafly.domain.member.web.dto.*;
+import com.hansung.leafly.domain.member.web.dto.info.BookSimple;
 import com.hansung.leafly.global.auth.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.hansung.leafly.domain.library.entity.enums.LibraryStatus;
 
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
@@ -79,5 +86,52 @@ public class MemberServiceImpl implements MemberService {
         }
 
         onboardingRepository.save(onboarding);
+    }
+
+    @Override
+    public MemberDetailsRes details(Member m) {
+        Member member = memberRepository.findDetailById(m.getId())
+                .orElseThrow(MemberNotFoundException::new);
+
+        String nickName = member.getNickName();
+        String profileImage = member.getImage(); // null 가능
+
+        // 서재, 북마크 가져오기
+        Set<Library> libraries = member.getLibraries();
+        Set<Bookmark> bookmarks = member.getBookmarks();
+
+        // 서재: 완독 책
+        List<BookSimple> finishedBooks = libraries.stream()
+                .filter(lib -> lib.getStatus() == LibraryStatus.DONE)
+                .map(lib -> new BookSimple(lib.getIsbn(), lib.getCover()))
+                .toList();
+
+        int finishedCount = finishedBooks.size();
+
+        // 서재: 읽고 싶음 책
+        List<BookSimple> wantBooks = libraries.stream()
+                .filter(lib -> lib.getStatus() == LibraryStatus.WANT_TO_READ)
+                .map(lib -> new BookSimple(lib.getIsbn(), lib.getCover()))
+                .toList();
+
+        int wantCount = wantBooks.size();
+
+        // 좋아요 LIST
+        List<BookSimple> likeBooks = bookmarks.stream()
+                .map(bm -> new BookSimple(String.valueOf(bm.getIsbn()), bm.getCover()))
+                .toList();
+
+        int likeCount = likeBooks.size();
+
+        return MemberDetailsRes.of(
+                nickName,
+                profileImage,
+                finishedCount,
+                finishedBooks,
+                wantCount,
+                wantBooks,
+                likeCount,
+                likeBooks
+        );
     }
 }

--- a/src/main/java/com/hansung/leafly/domain/member/web/controller/MemberController.java
+++ b/src/main/java/com/hansung/leafly/domain/member/web/controller/MemberController.java
@@ -45,4 +45,13 @@ public class MemberController {
         memberService.onboarding(memberDetails.getMember(), req);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created(null));
     }
+
+    //회원 정보 반환
+    @GetMapping
+    public ResponseEntity<SuccessResponse<MemberDetailsRes>> details(
+            @AuthenticationPrincipal CustomMemberDetails memberDetails
+    ){
+        MemberDetailsRes res = memberService.details(memberDetails.getMember());
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.from(res));
+    }
 }

--- a/src/main/java/com/hansung/leafly/domain/member/web/dto/MemberDetailsRes.java
+++ b/src/main/java/com/hansung/leafly/domain/member/web/dto/MemberDetailsRes.java
@@ -1,0 +1,40 @@
+package com.hansung.leafly.domain.member.web.dto;
+
+import com.hansung.leafly.domain.member.web.dto.info.BookSimple;
+import com.hansung.leafly.domain.member.web.dto.info.LibrarySection;
+import com.hansung.leafly.domain.member.web.dto.info.LikeSection;
+
+import java.util.List;
+
+public record MemberDetailsRes (
+        String nickName,
+        String profileImage,
+        LibrarySection library,
+        LikeSection likes
+){
+    public static MemberDetailsRes of(
+            String nickName,
+            String profileImage,
+            int finishedCount,
+            List<BookSimple> finishedBooks,
+            int wantCount,
+            List<BookSimple> wantBooks,
+            int likeCount,
+            List<BookSimple> likeBooks
+    ) {
+        return new MemberDetailsRes(
+                nickName,
+                profileImage,
+                new LibrarySection(
+                        finishedCount,
+                        finishedBooks,
+                        wantCount,
+                        wantBooks
+                ),
+                new LikeSection(
+                        likeCount,
+                        likeBooks
+                )
+        );
+    }
+}

--- a/src/main/java/com/hansung/leafly/domain/member/web/dto/info/BookSimple.java
+++ b/src/main/java/com/hansung/leafly/domain/member/web/dto/info/BookSimple.java
@@ -1,0 +1,6 @@
+package com.hansung.leafly.domain.member.web.dto.info;
+
+public record BookSimple(
+        String isbn,
+        String coverUrl
+) {}

--- a/src/main/java/com/hansung/leafly/domain/member/web/dto/info/LibrarySection.java
+++ b/src/main/java/com/hansung/leafly/domain/member/web/dto/info/LibrarySection.java
@@ -1,0 +1,10 @@
+package com.hansung.leafly.domain.member.web.dto.info;
+
+import java.util.List;
+
+public record LibrarySection(
+        int finishedCount,
+        List<BookSimple> finishedBooks,
+        int wantCount,
+        List<BookSimple> wantBooks
+) {}

--- a/src/main/java/com/hansung/leafly/domain/member/web/dto/info/LikeSection.java
+++ b/src/main/java/com/hansung/leafly/domain/member/web/dto/info/LikeSection.java
@@ -1,0 +1,8 @@
+package com.hansung.leafly.domain.member.web.dto.info;
+
+import java.util.List;
+
+public record LikeSection(
+        int likeCount,
+        List<BookSimple> likeBooks
+) {}


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #30
<br>

## ✅ 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 기능 수정

<br>

## ✨ 작업 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
### 1. 사용자 정보 반환
- 사용자 닉네임, 프로필 반환
- 사용자의 서재 목록과 좋아요를 누른 책 리스트 반환
<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->
1. 책 리스트 반환 시 추후 검색을 위한 isbn값과 표지 url을 반환하고 있습니다. 제목, 저자 추가는 바로 가능합니다.
2. 사용자의 서재 목록과 좋아요 목록들을 기존 List로 연관 관계 매핑을 해두었지만 두 가지를 동시에 join 시 문제가 발생하여 Set으로 바꾸었습니다. 반환 순서가 중요하지 않기에 사용하게 되었습니다.
<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [ ] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="688" height="584" alt="image" src="https://github.com/user-attachments/assets/d36b0f94-cb7f-426e-b5b0-b6877bc57240" />
