### PR TITLE
🐛 fix : 독후감 작성 시 해당 서재 '완독' 등록

### DIFF
--- a/src/main/java/com/hansung/leafly/domain/bookreview/web/dto/ReviewReq.java
+++ b/src/main/java/com/hansung/leafly/domain/bookreview/web/dto/ReviewReq.java
@@ -38,4 +38,7 @@ public class ReviewReq {
     // 이미지 최대 3개까지
     @Size(max = 3, message = "이미지는 최대 3장까지 업로드 가능합니다.")
     private List<MultipartFile> images;
+
+    @NotNull(message = "isbn을 입력해주세요.")
+    private String isbn;
 }

--- a/src/main/java/com/hansung/leafly/domain/library/entity/Library.java
+++ b/src/main/java/com/hansung/leafly/domain/library/entity/Library.java
@@ -51,4 +51,8 @@ public class Library extends BaseEntity {
                 .status(req.getStatus())
                 .build();
     }
+
+    public void updateStatus(LibraryStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/hansung/leafly/domain/library/repository/LibraryRepository.java
+++ b/src/main/java/com/hansung/leafly/domain/library/repository/LibraryRepository.java
@@ -5,8 +5,11 @@ import com.hansung.leafly.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface LibraryRepository extends JpaRepository<Library, Long> {
     boolean existsByMemberAndIsbn(Member member, String isbn13);
 
+    Optional<Library> findByMemberAndIsbn(Member member, String isbn);
 }

--- a/src/main/java/com/hansung/leafly/domain/library/web/dto/LibraryReq.java
+++ b/src/main/java/com/hansung/leafly/domain/library/web/dto/LibraryReq.java
@@ -4,8 +4,10 @@ import com.hansung.leafly.domain.library.entity.enums.LibraryStatus;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class LibraryReq {
     @NotBlank(message = "책 제목이 비어 있습니다.")
     private String title;

--- a/src/main/java/com/hansung/leafly/domain/library/web/dto/LibraryReqBuilder.java
+++ b/src/main/java/com/hansung/leafly/domain/library/web/dto/LibraryReqBuilder.java
@@ -1,0 +1,22 @@
+package com.hansung.leafly.domain.library.web.dto;
+
+import com.hansung.leafly.domain.bookreview.web.dto.ReviewReq;
+import com.hansung.leafly.domain.library.entity.enums.LibraryStatus;
+
+public class LibraryReqBuilder {
+
+    private final ReviewReq req;
+
+    public LibraryReqBuilder(ReviewReq req) {
+        this.req = req;
+    }
+
+    public LibraryReq buildDoneReq() {
+        LibraryReq libraryReq = new LibraryReq();
+        libraryReq.setTitle(req.getTitle());
+        libraryReq.setAuthor(req.getAuthor());
+        libraryReq.setCover(req.getThumbnail());
+        libraryReq.setStatus(LibraryStatus.DONE);
+        return libraryReq;
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- #34
<br>

## ✅ 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 기능 수정

<br>

## ✨ 작업 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
### 1. 독후감 등록 시 사용자 서재 '완독' 상태로 등록
- 기존 서재에 존재하지 않던 책이라면 **완독** 상태로 바로 등록
- 만약 **읽고 싶어요** 상태였다면 상태만 **완독**으로 변경
<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [ ] 코드가 컴파일 및 빌드됨
- [ ] 모든 테스트가 통과함
- [ ] 관련 문서가 업데이트됨
- [ ] 코드 리뷰가 수행됨
- [ ] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->